### PR TITLE
feat: Food Controller, Service, Repo 생성 및 의존성 주입

### DIFF
--- a/src/main/java/com/szincho/kimhyungjunproject/Food/FoodController.java
+++ b/src/main/java/com/szincho/kimhyungjunproject/Food/FoodController.java
@@ -1,0 +1,12 @@
+package com.szincho.kimhyungjunproject.Food;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class FoodController {
+
+    @Autowired
+    FoodService service;
+
+}

--- a/src/main/java/com/szincho/kimhyungjunproject/Food/FoodRepository.java
+++ b/src/main/java/com/szincho/kimhyungjunproject/Food/FoodRepository.java
@@ -1,0 +1,8 @@
+package com.szincho.kimhyungjunproject.Food;
+
+import com.szincho.kimhyungjunproject.Food.Entity.Food;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FoodRepository extends JpaRepository<Food, Integer> {
+
+}

--- a/src/main/java/com/szincho/kimhyungjunproject/Food/FoodService.java
+++ b/src/main/java/com/szincho/kimhyungjunproject/Food/FoodService.java
@@ -1,0 +1,12 @@
+package com.szincho.kimhyungjunproject.Food;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FoodService {
+
+    @Autowired
+    FoodRepository repo;
+
+}


### PR DESCRIPTION
Controller, Service, Repository 생성 및 어노테이션을 통해 의존성을 주입했습니다.

Repository의 경우 JPA Repository를 상속하면 내부적으로 빈으로 등록되는 것으로 알고 있어서 @Repository 어노테이션은 생략했습니다.
